### PR TITLE
fixed spotless build logic for win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,6 @@ if (NOT matlab )
   message(FATAL_ERROR "Could not find matlab executable")
 endif()
 
-add_custom_target(run ALL
-			  DEPENDS
-			  "${CMAKE_INSTALL_PREFIX}/matlab/addpath_spotless.m"
-			  "${CMAKE_INSTALL_PREFIX}/matlab/rmpath_spotless.m")
-
 add_custom_command(OUTPUT "${CMAKE_INSTALL_PREFIX}/matlab/addpath_spotless.m" "${CMAKE_INSTALL_PREFIX}/matlab/rmpath_spotless.m"
 			  COMMAND ${matlab} -wait -nosplash -nodesktop -nodisplay -r "\"cd('${CMAKE_CURRENT_SOURCE_DIR}');spot_pods_install('${CMAKE_INSTALL_PREFIX}/matlab','${relpath}');exit\""
 			  DEPENDS
@@ -28,4 +23,6 @@ add_custom_command(OUTPUT "${CMAKE_INSTALL_PREFIX}/matlab/addpath_spotless.m" "$
 			    "${CMAKE_CURRENT_SOURCE_DIR}/spot_pods_install.m"
         )
 
-add_custom_target(install DEPENDS all) 
+add_custom_target(install_spotless DEPENDS 
+			    "${CMAKE_INSTALL_PREFIX}/matlab/addpath_spotless.m"
+			    "${CMAKE_INSTALL_PREFIX}/matlab/rmpath_spotless.m") 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CMAKE_CONFIG=--config $(BUILD_TYPE)
 
 .PHONY: all
 all: configure
-	cmake --build pod-build $(CMAKE_CONFIG) --target install
+	cmake --build pod-build $(CMAKE_CONFIG) --target install_spotless
 
 pod-build:
 	cmake -E make_directory pod-build


### PR DESCRIPTION
There were 2 issues:

1. `install` is a reserved target name and has undefined behavior when used to define a custom target
2. The `install` target was depending on an `all` target which didn't exist.

