### PR TITLE
Removed call to ``get_relative_path`` and replaced it with the CMake …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 2.6.0)
 set(POD_NAME spotless)
 include(cmake/pods.cmake)
 
-get_relative_path("${CMAKE_INSTALL_PREFIX}/matlab" "${CMAKE_CURRENT_SOURCE_DIR}" relpath)
+file(RELATIVE_PATH relpath ${CMAKE_INSTALL_PREFIX}/matlab ${CMAKE_CURRENT_SOURCE_DIR})
 
 # setup matlab pods-compliance
 include(cmake/matlab_pods.cmake)


### PR DESCRIPTION
Removed call to ``get_relative_path`` and replaced it with CMake built in. See issue #1795. Will also create pull request for RobotLocomotion/cmake where the get_relative_path definition is.