### PR TITLE
Use matlab_add_mex and add unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,33 +8,70 @@ if(CMAKE_VERSION VERSION_LESS 3.7)
     ${CMAKE_MODULE_PATH})
 endif()
 
-find_package(Matlab REQUIRED COMPONENTS MAIN_PROGRAM)
+include(CTest)
+
+find_package(Matlab REQUIRED COMPONENTS MAIN_PROGRAM MEX_COMPILER MX_LIBRARY)
 
 set(SPOTLESS_MEX_DIR "${CMAKE_CURRENT_SOURCE_DIR}/spotless/mex")
 
-set(SPOTLESS_MEX_SOURCES
-  "${SPOTLESS_MEX_DIR}/spot_gset.c"
-  "${SPOTLESS_MEX_DIR}/spot_mex_helpers.cpp"
-  "${SPOTLESS_MEX_DIR}/spot_mex_msspoly_check_canonical.cpp"
+matlab_add_mex(NAME spot_gset SRC
+  "${SPOTLESS_MEX_DIR}/spot_gset.c")
+
+matlab_add_mex(NAME spot_mex_msspoly_check_canonical SRC
+  "${SPOTLESS_MEX_DIR}/spot_mex_msspoly_check_canonical.cpp")
+
+matlab_add_mex(NAME spot_mex_msspoly_make_canonical_combine_coeffs SRC
   "${SPOTLESS_MEX_DIR}/spot_mex_msspoly_make_canonical_combine_coeffs.cpp"
-  "${SPOTLESS_MEX_DIR}/spot_mex_msspoly_make_canonical_combine_powers.cpp")
+  "${SPOTLESS_MEX_DIR}/spot_mex_helpers.cpp")
 
-set(SPOTLESS_MEX_OUTPUTS
-  "${SPOTLESS_MEX_DIR}/spot_gset.${Matlab_MEX_EXTENSION}"
-  "${SPOTLESS_MEX_DIR}/spot_mex_msspoly_check_canonical.${Matlab_MEX_EXTENSION}"
-  "${SPOTLESS_MEX_DIR}/spot_mex_msspoly_make_canonical_combine_coeffs.${Matlab_MEX_EXTENSION}"
-  "${SPOTLESS_MEX_DIR}/spot_mex_msspoly_make_canonical_combine_powers.${Matlab_MEX_EXTENSION}")
+matlab_add_mex(NAME spot_mex_msspoly_make_canonical_combine_powers SRC
+  "${SPOTLESS_MEX_DIR}/spot_mex_msspoly_make_canonical_combine_powers.cpp"
+  "${SPOTLESS_MEX_DIR}/spot_mex_helpers.cpp")
 
-set(SPOTLESS_INSTALL_LOG "${CMAKE_CURRENT_BINARY_DIR}/spotless_install.log")
+set_target_properties(
+  spot_gset
+  spot_mex_msspoly_check_canonical
+  spot_mex_msspoly_make_canonical_combine_coeffs
+  spot_mex_msspoly_make_canonical_combine_powers
+  PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${SPOTLESS_MEX_DIR}"
+    LIBRARY_OUTPUT_DIRECTORY "${SPOTLESS_MEX_DIR}"
+    RUNTIME_OUTPUT_DIRECTORY "${SPOTLESS_MEX_DIR}")
 
-add_custom_command(
-  OUTPUT ${SPOTLESS_MEX_OUTPUTS}
-  COMMAND "${Matlab_MAIN_PROGRAM}" -logfile "${SPOTLESS_INSTALL_LOG}" -nosplash -nodesktop -nodisplay -wait -r "spot_install;exit"
-  DEPENDS ${SPOTLESS_MEX_SOURCES}
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/spotless"
-  COMMENT "Installing spotless...")
+if(BUILD_TESTING)
+  set(SPOTLESS_ADDITIONAL_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/spotless"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spotless/mex"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spotless/mss"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spotless/spotopt"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spotless/spotopt/solvers"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spotless/spotopt/util"
+    "${CMAKE_CURRENT_SOURCE_DIR}/spotless/util")
 
-add_custom_target(spotless_install ALL DEPENDS ${SPOTLESS_MEX_OUTPUTS})
+  matlab_add_unit_test(NAME spot_mex_test
+    UNITTEST_FILE "${SPOTLESS_MEX_DIR}/spot_mex_test.m"
+    TIMEOUT -1
+    ADDITIONAL_PATH "${SPOTLESS_ADDITIONAL_PATH}"
+    MATLAB_ADDITIONAL_STARTUP_OPTIONS -nojvm)
+
+  set(SPOTLESS_TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/spotless/tests")
+
+  matlab_add_unit_test(NAME msspoly_tests
+    UNITTEST_FILE "${SPOTLESS_TESTS_DIR}/msspoly_tests.m"
+    TIMEOUT -1
+    ADDITIONAL_PATH "${SPOTLESS_ADDITIONAL_PATH}"
+    MATLAB_ADDITIONAL_STARTUP_OPTIONS -nojvm)
+
+  option(HAVE_SEDUMI "SeDuMi is installed and in the MATLAB search path" OFF)
+
+  if(HAVE_SEDUMI)
+    matlab_add_unit_test(NAME mssprog_tests
+      UNITTEST_FILE "${SPOTLESS_TESTS_DIR}/mssprog_tests.m"
+      TIMEOUT -1
+      ADDITIONAL_PATH "${SPOTLESS_ADDITIONAL_PATH}"
+      MATLAB_ADDITIONAL_STARTUP_OPTIONS -nojvm)
+  endif()
+endif()
 
 configure_file(addpath_spotless.m.in addpath_spotless.m @ONLY)
 configure_file(rmpath_spotless.m.in rmpath_spotless.m @ONLY)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,6 @@
+set(CTEST_PROJECT_NAME spotless)
+set(CTEST_NIGHTLY_START_TIME "00:00:00 EST")
+set(CTEST_DROP_METHOD https)
+set(CTEST_DROP_SITE drake-cdash.csail.mit.edu)
+set(CTEST_DROP_LOCATION /submit.php?project=${CTEST_PROJECT_NAME})
+set(CTEST_DROP_SITE_CDASH ON)

--- a/cmake/modules/3.7/FindMatlab.cmake
+++ b/cmake/modules/3.7/FindMatlab.cmake
@@ -1,3 +1,10 @@
+#=============================================================================
+# NOTICE: This file is not an exact copy of FindMatlab.cmake from upstream.
+#
+# Improvements made in the upstream version depend on changes to the CMake C++
+# source code. This copy has been modified to incorporate similar improvements
+# without depending on the newer version of CMake.
+#=============================================================================
 #.rst:
 # FindMatlab
 # ----------
@@ -804,30 +811,39 @@ function(matlab_add_unit_test)
   endif()
 
   set(options NO_UNITTEST_FRAMEWORK)
-  set(oneValueArgs NAME UNITTEST_FILE TIMEOUT WORKING_DIRECTORY
+  set(oneValueArgs NAME UNITTEST_FILE TIMEOUT WORKING_DIRECTORY)
+  set(multiValueArgs ADDITIONAL_PATH MATLAB_ADDITIONAL_STARTUP_OPTIONS TEST_ARGS
     UNITTEST_PRECOMMAND CUSTOM_TEST_COMMAND)
-  set(multiValueArgs ADDITIONAL_PATH MATLAB_ADDITIONAL_STARTUP_OPTIONS TEST_ARGS)
 
   set(prefix _matlab_unittest_prefix)
-  cmake_parse_arguments(PARSE_ARGV 0 ${prefix} "${options}" "${oneValueArgs}" "${multiValueArgs}" )
+  cmake_parse_arguments(${prefix} "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
   if(NOT ${prefix}_NAME)
     message(FATAL_ERROR "[MATLAB] The Matlab test name cannot be empty")
   endif()
 
+  # Escape MATLAB commands so they can be passed to add_test and to
+  # cmake -P script.
+  string(REPLACE "\"" "" custom_test_cmd_clean "${${prefix}_CUSTOM_TEST_COMMAND}")
+  string(REPLACE ";" "\\;" custom_test_cmd_clean "${custom_test_cmd_clean}")
+  string(REPLACE "\"" "" unittest_precmd_clean "${${prefix}_UNITTEST_PRECOMMAND}")
+  string(REPLACE ";" "\\;" unittest_precmd_clean "${unittest_precmd_clean}")
+  string(REPLACE " " "\ " unittest_precmd_clean "${unittest_precmd_clean}")
+  string(REPLACE ";" "\\;" additional_path_clean "${${prefix}_ADDITIONAL_PATH}")
+
   add_test(NAME ${${prefix}_NAME}
            COMMAND ${CMAKE_COMMAND}
-            "-Dtest_name=${${prefix}_NAME}"
-            "-Dadditional_paths=${${prefix}_ADDITIONAL_PATH}"
-            "-Dtest_timeout=${${prefix}_TIMEOUT}"
-            "-Doutput_directory=${_matlab_temporary_folder}"
-            "-Dworking_directory=${${prefix}_WORKING_DIRECTORY}"
-            "-DMatlab_PROGRAM=${Matlab_MAIN_PROGRAM}"
-            "-Dno_unittest_framework=${${prefix}_NO_UNITTEST_FRAMEWORK}"
-            "-DMatlab_ADDITIONNAL_STARTUP_OPTIONS=${${prefix}_MATLAB_ADDITIONAL_STARTUP_OPTIONS}"
-            "-Dunittest_file_to_run=${${prefix}_UNITTEST_FILE}"
-            "-Dcustom_Matlab_test_command=${${prefix}_CUSTOM_TEST_COMMAND}"
-            "-Dcmd_to_run_before_test=${${prefix}_UNITTEST_PRECOMMAND}"
+            -Dtest_name=${${prefix}_NAME}
+            -Dadditional_paths=${additional_path_clean}
+            -Dtest_timeout=${${prefix}_TIMEOUT}
+            -Doutput_directory=${_matlab_temporary_folder}
+            -Dworking_directory=${${prefix}_WORKING_DIRECTORY}
+            -DMatlab_PROGRAM=${Matlab_MAIN_PROGRAM}
+            -Dno_unittest_framework=${${prefix}_NO_UNITTEST_FRAMEWORK}
+            -DMatlab_ADDITIONNAL_STARTUP_OPTIONS=${${prefix}_MATLAB_ADDITIONAL_STARTUP_OPTIONS}
+            -Dunittest_file_to_run=${${prefix}_UNITTEST_FILE}
+            -Dcustom_Matlab_test_command=${custom_test_cmd_clean}
+            -Dcmd_to_run_before_test=${unittest_precmd_clean}
             -P ${_FindMatlab_SELF_DIR}/MatlabTestsRedirect.cmake
            ${${prefix}_TEST_ARGS}
            ${${prefix}_UNPARSED_ARGUMENTS}


### PR DESCRIPTION
It seems using `mex` at all is proving too flaky, especially with Windows builds, so bypassing it completely using the functions from the latest `FindMatlab` from CMake 3.7 seems the only real option now. This also adds unit tests, so that we can more easily verify that everything is good with MEX. 